### PR TITLE
PROD-2144 Deploy PROD-120 remove find me data from work type options-> master

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -310,7 +310,7 @@ export const webWorkTypes = [
       : findMeDataConfigs.BASE_PRODUCT_PRICE,
     stickerPrice: findMeDataConfigs.BASE_PRODUCT_PRICE,
     duration: `${findMeDataConfigs.DEFAULT_DURATION} Days`,
-    featured: true,
+    featured: false,
     startRoute: "/self-service/work/new/find-me-data/basic-info",
     helperBannerTitle: "WHAT WILL I RECEIVE?",
     helperBannerContent: (


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-2144

The Find me data intake should not be visible on the Select Work Type page. But it is still available at 

/self-service/work/new/find-me-data/basic-info