### PR TITLE
PROD-2122 Redirect to work dashboard when user is log in -> Dev

### DIFF
--- a/src/routes/LoginPrompt/index.jsx
+++ b/src/routes/LoginPrompt/index.jsx
@@ -27,6 +27,7 @@ const LoginPrompt = ({
 
   useEffect(() => {
     if (isLoggedIn) {
+      // What should be the change here?
       navigate(nextPageUrl || "/self-service/branding");
       setProgressItem(5);
     }

--- a/src/routes/LoginPrompt/index.jsx
+++ b/src/routes/LoginPrompt/index.jsx
@@ -13,6 +13,7 @@ import "./styles.module.scss";
 import PageFoot from "components/PageElements/PageFoot";
 import PageDivider from "components/PageDivider";
 import BackIcon from "../../assets/images/icon-back-arrow.svg";
+import { ROUTES } from "../../constants";
 
 /**
  * Log in Page
@@ -27,7 +28,7 @@ const LoginPrompt = ({
 
   useEffect(() => {
     if (isLoggedIn) {
-      navigate(nextPageUrl || "/work/dashboard");
+      navigate(nextPageUrl || ROUTES.DASHBOARD_PAGE);
       setProgressItem(5);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/routes/LoginPrompt/index.jsx
+++ b/src/routes/LoginPrompt/index.jsx
@@ -27,8 +27,7 @@ const LoginPrompt = ({
 
   useEffect(() => {
     if (isLoggedIn) {
-      // What should be the change here?
-      navigate(nextPageUrl || "/self-service/branding");
+      navigate(nextPageUrl || "/work/dashboard");
       setProgressItem(5);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
What's this PR is about?

I want to discuss in the PR whether we need to fix this url. 

Context:

In login-prompt component, the fallback url is hardcoded to "/self-service/branding" which is the old branding url. 

There are two scenario's here, 

1. When user is log in
2. When user is not log in

Scenario 1(When user is log in):

1. Going to this url(https://platform.topcoder-dev.com/self-service/login-prompt) redirects to the old branding page(https://platform.topcoder-dev.com/self-service/branding)

Scenario 2(When user is not log in):
1. Going to login prompt url(https://platform.topcoder-dev.com/self-service/login-prompt) does not redirect but displays the login prompt page(which is correct I believe).

@brooketopcoder Personally I think the scenario 1 is not valid since the user won't be going to login-prompt if they are already log in. Do I have to fix the url here? Am I missing something else because of my restricted knowledge in existing functionality?

Thanks!