### PR TITLE
Prod 1488 course assessment screen

### DIFF
--- a/src-ts/tools/learn/course-details/course-curriculum/curriculum-summary/CurriculumSummary.tsx
+++ b/src-ts/tools/learn/course-details/course-curriculum/curriculum-summary/CurriculumSummary.tsx
@@ -20,7 +20,7 @@ const CurriculumSummary: FC<CurriculumSummaryProps> = (props: CurriculumSummaryP
 
     return (
         <div className={styles['wrap']}>
-            {inProgress && (
+            {(inProgress || completed) && (
                 <>
                     <div className={styles['title']}>
                         {completed ? (

--- a/src-ts/tools/learn/learn-lib/course-outline/collapsible-item/CollapsibleItem.module.scss
+++ b/src-ts/tools/learn/learn-lib/course-outline/collapsible-item/CollapsibleItem.module.scss
@@ -7,6 +7,7 @@
 
 .title-row {
     display: flex;
+    align-items: flex-start;
     gap: calc($pad-sm + $border);
     cursor: pointer;
 
@@ -20,6 +21,16 @@
         width: $pad-xxl;
         height: $pad-xxl;
     }
+}
+
+.title-tag {
+    color: $blue-140;
+    background: $tc-white;
+    padding: calc($border + $border-xs) $pad-xs;
+    border-radius: $border;
+    text-transform: uppercase;
+    line-height: 10px;
+    margin-top: $pad-xs;
 }
 
 .chevron {

--- a/src-ts/tools/learn/learn-lib/course-outline/collapsible-item/CollapsibleItem.tsx
+++ b/src-ts/tools/learn/learn-lib/course-outline/collapsible-item/CollapsibleItem.tsx
@@ -30,6 +30,8 @@ interface CollapsibleItemProps {
 const CollapsibleItem: FC<CollapsibleItemProps> = (props: CollapsibleItemProps) => {
     const [isOpen, setIsOpen]: [boolean, Dispatch<SetStateAction<boolean>>] = useState<boolean>(false)
 
+    const isAssessment = props.lessonsCount === 1;
+    
     const toggle: () => void = useCallback(() => {
         setIsOpen(open => !open)
     }, [])
@@ -52,7 +54,7 @@ const CollapsibleItem: FC<CollapsibleItemProps> = (props: CollapsibleItemProps) 
 
     const listItem: (item: any, isActive?: boolean) => ReactNode = (item: any, isActive?: boolean) => (
         <StepIcon
-            index={item.dashedName.split('-').pop()}
+            index={`${parseInt(item.dashedName.split('-').pop()) || 1}`}
             completed={isItemCompleted(item.dashedName)}
             active={isActive}
         />
@@ -62,6 +64,11 @@ const CollapsibleItem: FC<CollapsibleItemProps> = (props: CollapsibleItemProps) 
         <div className={classNames(styles['wrap'], isOpen ? 'is-open' : 'collapsed')}>
             <div className={styles['title-row']} onClick={toggle}>
                 <StatusIcon completed={isCompleted} partial={isPartial} />
+                {isAssessment && (
+                    <div className={classNames(styles['title-tag'], 'label')}>
+                        assessment
+                    </div>
+                )}
                 <span className={styles['title']}>
                     {props.title}
                 </span>


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-1488

- update UI in course outline to show the "Assessment" tag for the assessment modules.
- fix course summary in course details screen

Related PR: https://github.com/topcoder-platform/freeCodeCamp/pull/7