### PR TITLE
PROD-1038  updated timeline for data advisory -> develop

### DIFF
--- a/src/constants/products/DataAdvisory/index.js
+++ b/src/constants/products/DataAdvisory/index.js
@@ -34,12 +34,12 @@ export const DEFAULT_TIMELINE = [
   {
     // Appeals
     phaseId: "1c24cfb3-5b0a-4dbd-b6bd-4b0dff5349c6",
-    duration: 43200,
+    duration: 86400,
   },
   {
     // Appeals response
     phaseId: "797a6af7-cd3f-4436-9fca-9679f773bee9",
-    duration: 43200,
+    duration: 259200,
   },
 ];
 


### PR DESCRIPTION
What's in this PR?

- Updated the timeline phases of the data advisory intakes.

<img width="1236" alt="Screenshot 2022-06-22 at 18 32 53" src="https://user-images.githubusercontent.com/10268304/175088570-df709663-292a-4def-87df-47b3ee7af519.png">

