### PR TITLE
PROD-2399 Redirect all Request to Platform UI -> develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Topcoder Self Service Micro Frontend App
 
+# THIS APP IS OBSOLETE!! YAY!!
+
+>**NOTE:** As of PROD-2194, this repo will obsolete.
+
+All requests to this app should be redirected to the new [platform ui](https://github.com/topcoder-platform/platform-ui).
+
+If for some bizarre reason you need to run this repo, you can replace the root.component.jsx with the root.component.jsx.bak, and it will work normally.
+
+# THIS APP IS OBSOLETE! PAY NO ATTN TO ANYTHING BELOW
+
 This is a [single-spa](https://single-spa.js.org/) React microapp that runs within the `mfe-core` frame application. 
 
 > **NOTE:** This application has been configured to be run as child app of a single-spa application. So while this app can be deployed and run independently, we would need some frame [single-spa](https://single-spa.js.org/) which would load it. While technically we can achieve running this app as standalone app it's strongly not recommended by the author of the `single-spa` approch, see this [GitHub Issue](https://github.com/single-spa/single-spa/issues/640) for details.

--- a/src-ts/config/environments/environment.default.config.ts
+++ b/src-ts/config/environments/environment.default.config.ts
@@ -18,5 +18,6 @@ export const EnvironmentConfigDefault: GlobalConfig = {
     TAG_MANAGER_ID: undefined,
     URL: {
         ACCOUNTS_APP_CONNECTOR: 'https://accounts-auth0.topcoder-dev.com',
+        PLATFORM_UI: 'https://local.topcoder-dev.com:3000',
     },
 }

--- a/src-ts/config/environments/environment.dev.config.ts
+++ b/src-ts/config/environments/environment.dev.config.ts
@@ -1,14 +1,14 @@
 import { GlobalConfig } from '../../lib'
-import { ToolTitle } from '../constants'
 
 import { AppHostEnvironment } from './app-host-environment.enum'
 import { EnvironmentConfigDefault } from './environment.default.config'
 
 export const EnvironmentConfigDev: GlobalConfig = {
     ...EnvironmentConfigDefault,
-    DISABLED_TOOLS: [
-        ToolTitle.designLib,
-    ],
+    DISABLED_TOOLS: [ ],
     ENV: AppHostEnvironment.dev,
     TAG_MANAGER_ID: 'GTM-W7B537Z',
+    URL: {
+        PLATFORM_UI: 'https://platform-ui.topcoder-dev.com',
+    },
 }

--- a/src-ts/config/environments/environment.prod.config.ts
+++ b/src-ts/config/environments/environment.prod.config.ts
@@ -1,5 +1,4 @@
 import { GlobalConfig } from '../../lib'
-import { ToolTitle } from '../constants'
 
 import { AppHostEnvironment } from './app-host-environment.enum'
 import { EnvironmentConfigDefault } from './environment.default.config'
@@ -11,12 +10,10 @@ export const EnvironmentConfigProd: GlobalConfig = {
         V3: 'https://api.topcoder.com/v3',
         V5: 'https://api.topcoder.com/v5',
     },
-    DISABLED_TOOLS: [
-        ToolTitle.designLib,
-    ],
     ENV: AppHostEnvironment.prod,
     TAG_MANAGER_ID: 'GTM-MXXQHG8',
     URL: {
         ACCOUNTS_APP_CONNECTOR: 'https://accounts-auth0.topcoder.com',
+        PLATFORM_UI: 'https://platform-ui.topcoder.com',
     },
 }

--- a/src-ts/lib/global-config.model.ts
+++ b/src-ts/lib/global-config.model.ts
@@ -14,6 +14,7 @@ export interface GlobalConfig {
     REAUTH_OFFSET: number
     TAG_MANAGER_ID?: string
     URL: {
-        ACCOUNTS_APP_CONNECTOR: string
+        ACCOUNTS_APP_CONNECTOR: string,
+        PLATFORM_UI: string
     }
 }

--- a/src/root.component.jsx
+++ b/src/root.component.jsx
@@ -1,61 +1,7 @@
-import { createHistory, LocationProvider } from "@reach/router";
-import React, { StrictMode } from "react";
-import { Provider } from "react-redux";
-import { BrowserRouter } from "react-router-dom";
-import ReduxToastr from "react-redux-toastr";
-
-import {
-  AppNextGen,
-  RouteProvider,
-  routeRootLoggedIn,
-  routeRootLoggedOut,
-  ToolsRoutes,
-  UtilsRoutes,
-  PageFooter,
-  ProfileProvider,
-} from "../src-ts";
-
-import App from "./App";
-import store from "./store";
-
-import "./styles/main.vendor.scss";
-
-const history = createHistory(window);
+import { EnvironmentConfig } from "../src-ts"
 
 export default function Root() {
-  return (
-    <Provider store={store}>
-      <ProfileProvider>
-        <BrowserRouter>
-          <RouteProvider
-            rootLoggedIn={routeRootLoggedIn}
-            rootLoggedOut={routeRootLoggedOut}
-            toolsRoutes={[...ToolsRoutes]}
-            utilsRoutes={[...UtilsRoutes]}
-          >
-            <StrictMode>
-              <AppNextGen />
-            </StrictMode>
-          </RouteProvider>
-        </BrowserRouter>
-
-        <LocationProvider history={history}>
-          <App />
-          <ReduxToastr
-            timeOut={3000}
-            newestOnTop={false}
-            preventDuplicates
-            position="top-right"
-            getState={(state) => state.toastr}
-            transitionIn="fadeIn"
-            transitionOut="fadeOut"
-            progressBar
-            closeOnToastrClick
-          />
-        </LocationProvider>
-
-        <PageFooter />
-      </ProfileProvider>
-    </Provider>
-  );
+    const redirectUrl = `${EnvironmentConfig.URL.PLATFORM_UI}${window.location.pathname}`
+    window.location.href = redirectUrl
+    return <></>
 }

--- a/src/root.component.jsx.bak
+++ b/src/root.component.jsx.bak
@@ -1,0 +1,61 @@
+import { createHistory, LocationProvider } from "@reach/router";
+import React, { StrictMode } from "react";
+import { Provider } from "react-redux";
+import { BrowserRouter } from "react-router-dom";
+import ReduxToastr from "react-redux-toastr";
+
+import {
+  AppNextGen,
+  RouteProvider,
+  routeRootLoggedIn,
+  routeRootLoggedOut,
+  ToolsRoutes,
+  UtilsRoutes,
+  PageFooter,
+  ProfileProvider,
+} from "../src-ts";
+
+import App from "./App";
+import store from "./store";
+
+import "./styles/main.vendor.scss";
+
+const history = createHistory(window);
+
+export default function Root() {
+  return (
+    <Provider store={store}>
+      <ProfileProvider>
+        <BrowserRouter>
+          <RouteProvider
+            rootLoggedIn={routeRootLoggedIn}
+            rootLoggedOut={routeRootLoggedOut}
+            toolsRoutes={[...ToolsRoutes]}
+            utilsRoutes={[...UtilsRoutes]}
+          >
+            <StrictMode>
+              <AppNextGen />
+            </StrictMode>
+          </RouteProvider>
+        </BrowserRouter>
+
+        <LocationProvider history={history}>
+          <App />
+          <ReduxToastr
+            timeOut={3000}
+            newestOnTop={false}
+            preventDuplicates
+            position="top-right"
+            getState={(state) => state.toastr}
+            transitionIn="fadeIn"
+            transitionOut="fadeOut"
+            progressBar
+            closeOnToastrClick
+          />
+        </LocationProvider>
+
+        <PageFooter />
+      </ProfileProvider>
+    </Provider>
+  );
+}


### PR DESCRIPTION
This PR redirects all requests to this app to the new Platform UI domain.

To test locally, run the MFE:

mfe-header = PROD-2399_urls
mfe-core = develop

Go to any URL, and you should be redirected to the identical path on the platform-ui domain.

> **Please note** that the platform-ui domain will be changing tonight from platform-mvp.topcoder-dev.com to platform-ui.topcoder-dev.com, so the page to which this branch redirects won't actually be available until tomorrow.